### PR TITLE
lib/calendarium-romanum/temporale.rb (CalendariumRomanum::Temporale#holy_family): Changed to handle case when "a Sunday does not occur between December 25 and January 1"

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 Ruby gem for
 calendar computations according to the Roman Catholic liturgical
 calendar as instituted by
-[MP Mysterii Paschalis](http://w2.vatican.va/content/paul-vi/en/motu_proprio/documents/hf_p-vi_motu-proprio_19690214_mysterii-paschalis.htm) of Paul VI. (AAS 61 (1969), pp. 222-226).
+[MP Mysterii Paschalis](http://w2.vatican.va/content/paul-vi/en/motu_proprio/documents/hf_p-vi_motu-proprio_19690214_mysterii-paschalis.html) of Paul VI. (AAS 61 (1969), pp. 222-226).
 The rules are defined in General Norms for the Liturgical Year
 and the Calendar
 ([English translation](https://www.ewtn.com/library/CURIA/CDWLITYR.HTM)).

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 Ruby gem for
 calendar computations according to the Roman Catholic liturgical
 calendar as instituted by
-MP Mysterii Paschalis of Paul VI. ([AAS 61 (1969)](http://www.vatican.va/archive/aas/documents/AAS-61-1969-ocr.pdf), pp. 222-226).
+[MP Mysterii Paschalis](http://w2.vatican.va/content/paul-vi/en/motu_proprio/documents/hf_p-vi_motu-proprio_19690214_mysterii-paschalis.htm) of Paul VI. (AAS 61 (1969), pp. 222-226).
 The rules are defined in General Norms for the Liturgical Year
 and the Calendar
 ([English translation](https://www.ewtn.com/library/CURIA/CDWLITYR.HTM)).

--- a/lib/calendarium-romanum/temporale.rb
+++ b/lib/calendarium-romanum/temporale.rb
@@ -129,7 +129,13 @@ module CalendariumRomanum
     end
 
     def holy_family(year=nil)
-      sunday_after(nativity(year))
+      year ||= @year
+      xmas = nativity(year)
+      if xmas.sunday?
+        return Date.new(year, 12, 30) # and only 1 reading before Gospel
+      else
+        sunday_after(xmas)
+      end
     end
 
     def mother_of_god(year=nil)

--- a/lib/calendarium-romanum/temporale.rb
+++ b/lib/calendarium-romanum/temporale.rb
@@ -132,7 +132,7 @@ module CalendariumRomanum
       year ||= @year
       xmas = nativity(year)
       if xmas.sunday?
-        return Date.new(year, 12, 30) # and only 1 reading before Gospel
+        return Date.new(year, 12, 30)
       else
         sunday_after(xmas)
       end

--- a/spec/temporale_spec.rb
+++ b/spec/temporale_spec.rb
@@ -221,12 +221,14 @@ describe CR::Temporale do
           expect(c.rank).to eq CR::Ranks::FEAST_LORD_GENERAL
           expect(c.title).to eq 'The Holy Family of Jesus, Mary and Joseph'
           expect(c.colour).to eq CR::Colours::WHITE
+        end
 
-          @t17 = described_class.new 2016
-          c = @t17.get(12, 30)
-          expect(c.rank).to eq CR::Ranks::FEAST_LORD_GENERAL
-          expect(c.title).to eq 'The Holy Family of Jesus, Mary and Joseph'
-          expect(c.colour).to eq CR::Colours::WHITE
+        context 'when a Sunday does not occur between Dec 25 and Jan 1' do
+          it 'is Holy Family on Friday Dec 30' do
+            @t16 = described_class.new 2016
+            c = @t16.get(12, 30)
+            expect(c.title).to eq 'The Holy Family of Jesus, Mary and Joseph'
+          end
         end
 
         it 'Epiphany' do

--- a/spec/temporale_spec.rb
+++ b/spec/temporale_spec.rb
@@ -221,6 +221,12 @@ describe CR::Temporale do
           expect(c.rank).to eq CR::Ranks::FEAST_LORD_GENERAL
           expect(c.title).to eq 'The Holy Family of Jesus, Mary and Joseph'
           expect(c.colour).to eq CR::Colours::WHITE
+
+          @t17 = described_class.new 2016
+          c = @t17.get(12, 30)
+          expect(c.rank).to eq CR::Ranks::FEAST_LORD_GENERAL
+          expect(c.title).to eq 'The Holy Family of Jesus, Mary and Joseph'
+          expect(c.colour).to eq CR::Colours::WHITE
         end
 
         it 'Epiphany' do


### PR DESCRIPTION
lib/calendarium-romanum/temporale.rb (CalendariumRomanum::Temporale#holy_family): Changed to handle case when "a Sunday does not occur between December 25 and January 1"

* lib/calendarium-romanum/temporale.rb (CalendariumRomanum::Temporale#holy_family):
* spec/temporale_spec.rb:
Changed to handle case when "a Sunday does not occur between December 25 and January 1".