### PR TITLE
Fixed query output for a season

### DIFF
--- a/lib/calendarium-romanum/cli.rb
+++ b/lib/calendarium-romanum/cli.rb
@@ -31,7 +31,7 @@ module CalendariumRomanum
       day = calendar.day date
 
       puts date
-      puts "season: #{day.season}"
+      puts "season: #{day.season.name}"
       puts
 
       rank_length = day.celebrations.collect {|c| c.rank.short_desc.size }.max

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -53,5 +53,14 @@ describe CalendariumRomanum::CLI, type: :aruba do
         it { expect(last_command).to be_successfully_executed }
       end
     end
+
+    describe 'query' do
+      describe 'correct season naming' do
+        before(:each) { run "calendariumrom query 2017-10-03" }
+
+        it { expect(all_output).to include "season: Ordinary Time" }
+        it { expect(last_command).to be_successfully_executed }
+      end
+    end
   end
 end


### PR DESCRIPTION
I have fixed the query output for a season. To achieve this, i simply have defined another attribute, `@name` for a season object which contains the name of the season in human readable format (speak: a string). 
So, `calendariumrom query` just has to output `day.season.name` instead of `day.season` and we're good to go. 