### PR TITLE
Implemented time range querying

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *~
 .rvmrc
+*.gem
+coverage/

--- a/README.md
+++ b/README.md
@@ -411,7 +411,7 @@ temporale.get(Date.new(2017, 11, 25)) # => #<CalendariumRomanum::Celebration:0x0
 ```
 ## Executable
 This gem provides an executable, `calendariumrom`, which can be used for querying the sanctorale data files from command line. It currently has 5 subcommands:
- - `calendariumrom query --calendar universal-fr 2007-06-25` queries a non-default (French) calendar for any given date. `--calendar` can be omitted, the default calendar (`universal-en`) is used then. The date can be omitted as well, `calendariumrom` will query the current date, then. Please note that the date has to be in a format Ruby's `Date::parse` can understand.
+ - `calendariumrom query --calendar universal-fr 2007-06-25` queries a non-default (French) calendar for any given date. `--calendar` can be omitted, the default calendar (`universal-en`) is used then. The date can be omitted as well, `calendariumrom` will query the current date, then. Please note that the date has to be in format `YYYY-MM-DD` or `YYYY/MM/DD`. If the day, or even the month is omitted, `query` will query a whole month, or even a whole year. 
  - `calendariumrom calendars` will list all available data files known to calendarium-romanum. 
  - `calendariumrom cmp FILE1 FILE2` will load 2 data files from the file system and compare them. If there are any differences in rank or colour of corresponding celebrations, it will output them. 
  - `calendariumrom errors FILE1, ...` finds errors in a data file. It tries to load it from file system, and if the parser will fail, for whatever reason, it will print out the reason. 

--- a/lib/calendarium-romanum/cli.rb
+++ b/lib/calendarium-romanum/cli.rb
@@ -17,29 +17,21 @@ module CalendariumRomanum
       end
       sanctorale = data_file.load
 
-      date =
-        if date_str
-          begin
-            Date.parse(date_str)
-          rescue ArgumentError
-            die! 'Invalid date.'
+      pcal = PerpetualCalendar.new sanctorale: sanctorale
+
+      if date_str
+        begin
+          parsed_date = DateParser.new(date_str)
+          parsed_date.date_range.each do |day|
+            print_single_date(pcal, day)
           end
-        else
-          Date.today
+        rescue ArgumentError
+          die! 'Invalid date.'
         end
-      calendar = Calendar.for_day(date, sanctorale)
-      day = calendar.day date
-
-      puts date
-      puts "season: #{day.season.name}"
-      puts
-
-      rank_length = day.celebrations.collect {|c| c.rank.short_desc.size }.max
-      day.celebrations.each do |c|
-        print c.rank.short_desc.rjust(rank_length)
-        print ' : '
-        puts c.title
+      else
+        print_single_date(pcal, Date.today)
       end
+
     end
 
     desc 'calendars', 'lists calendars available for querying'
@@ -115,5 +107,23 @@ module CalendariumRomanum
       STDERR.puts message
       exit code
     end
+
+    def print_single_date(calendar, date)
+      day = calendar.day date
+
+      puts date
+      puts "season: #{day.season.name}"
+      puts
+
+      rank_length = day.celebrations.collect {|c| c.rank.short_desc.nil? ? 0 : c.rank.short_desc.size}.max
+      day.celebrations.each do |c|
+        unless c.rank.short_desc.nil?
+          print c.rank.short_desc.rjust(rank_length)
+          print ' : '
+          puts c.title
+        end
+      end
+    end
+
   end
 end

--- a/lib/calendarium-romanum/util.rb
+++ b/lib/calendarium-romanum/util.rb
@@ -36,5 +36,27 @@ module CalendariumRomanum
         @prop = :month
       end
     end
+
+    class DateParser
+      attr_reader :date_range
+      def initialize(date_str)
+        if (date_str =~ /((\d{4})(\/|-)?(\d{0,2})(\/|-)?(\d{0,2}))\z/) # Accepts YYYY-MM-DD, YYYY/MM/DD where both day and month are optional
+          year = $2.to_i
+          month = $4.to_i 
+          day = $6.to_i
+          if ((day == 0) && (month == 0)) # Only year is given
+            @date_range = Year.new(year)
+          elsif (day == 0) # Year and month are given
+            @date_range = Month.new(year, month)
+          else
+            @date_range = Date.new(year, month, day)..Date.new(year, month, day)
+          end
+        else
+          raise ArgumentError, "Unparseable date"
+        end
+      end
+    end
+
+
   end
 end

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -109,6 +109,22 @@ describe CalendariumRomanum::CLI, type: :aruba do
         it { expect(all_output).to include "season: Ordinary Time" }
         it { expect(last_command).to be_successfully_executed }
       end
+
+      describe 'correct month querying' do
+        before(:each) { run "calendariumrom query 2015-06" }
+
+        it { expect(all_output).to include "Saint Cyril of Alexandria"}
+        it { expect(all_output).to include "Saint Anthony of Padua, priest and doctor"}
+        it { expect(last_command).to be_successfully_executed }
+      end
+
+      describe 'correct year querying' do
+        before(:each) { run "calendariumrom query 2013" }
+        
+        it { expect(all_output).to include "Saint John the Apostle and evangelist"}
+        it { expect(all_output).to include "Saint Paul of the Cross, priest"}
+        it { expect(last_command).to be_successfully_executed }
+      end
     end
 
     describe 'calendars' do

--- a/spec/date_parser_spec.rb
+++ b/spec/date_parser_spec.rb
@@ -1,0 +1,68 @@
+require 'spec_helper'
+
+describe CR::Util::DateParser do
+  describe 'new' do
+    it 'should accept a full date YYYY/MM/DD' do
+      date_str = "2017/10/06"
+      expect do
+        described_class.new(date_str)
+      end.not_to raise_exception
+    end
+
+    it 'should accept a full date YYYY-MM-DD' do
+      date_str = "2017-10-06"
+      expect do
+        described_class.new(date_str)
+      end.not_to raise_exception
+    end
+
+    it 'should accept a month range YYYY/MM' do
+      date_str = "2017/10"
+      expect do
+        described_class.new(date_str)
+      end.not_to raise_exception
+    end
+
+    it 'should accept a month range YYYY-MM' do
+      date_str = "2017-10"
+      expect do
+        described_class.new(date_str)
+      end.not_to raise_exception
+    end
+
+    it 'should accept a year range YYYY' do
+      date_str = "2017"
+      expect do 
+        described_class.new(date_str)
+      end.not_to raise_exception
+    end
+
+    it 'should not accept an invalid month' do
+      date_str = "2017-15"
+      expect do 
+        described_class.new(date_str)
+      end.to raise_exception(ArgumentError)
+    end
+
+    it 'should not accept an invalid day' do
+      date_str = "2017-10-48"
+      expect do
+        described_class.new(date_str)
+      end.to raise_exception(ArgumentError)
+    end
+
+    it 'should not accept a not-matching string' do
+      date_str = "foobar"
+      expect do
+        described_class.new(date_str)
+      end.to raise_exception(ArgumentError)
+    end
+
+    it 'should not accept an empty string' do
+      date_str = ""
+      expect do
+        described_class.new(date_str)
+      end.to raise_exception(ArgumentError)
+    end
+  end
+end


### PR DESCRIPTION
I have implemented time range querying. Unfortunately, Ruby's `Date::parse` method only accepts full dates, speak: with year, month and day, so it is not possible to parse incomplete dates which specify time ranges. 
To solve this, i have created some switches, combined with regular expressions and tried to parse the given date by hand. I do not know what formats `Date::parse` accepts, so my regexps only accept `YYYY-MM-DD` and `YYYY/MM/DD` for now. If desired, i can add other formats with even more regular expressions. 

For now, both acceptable formats are mentioned in the README, and the reference to the `Date::parse` method was removed from the README.

Furthermore, i fixed https://github.com/igneus/calendarium-romanum/issues/10. The solution you posted in this issue didn't work for me (at least with Ruby 2.4.2), so i solved it with a ternary operator. I hope it's okay. 

And last, but not least, a change so small that i didn't want to create another branch for it: I added built gems to the gitignore. I don't know your workflow, but i used `gem build` and `gem install` every time i wanted to test my code manually, which resulted in a built gem inside the work dir, which one could accidentally commit when using `git add .`, so i excluded it in the gitignore. 


