### PR TITLE
to_s implementation for season and colour

### DIFF
--- a/lib/calendarium-romanum/enums.rb
+++ b/lib/calendarium-romanum/enums.rb
@@ -12,6 +12,10 @@ module CalendariumRomanum
     def name
       I18n.t @i18n_key
     end
+
+    def to_s
+      name
+    end
   end
 
   class Colours < Enum
@@ -39,6 +43,10 @@ module CalendariumRomanum
 
     def name
       I18n.t @i18n_key
+    end
+
+    def to_s
+      name
     end
   end
 

--- a/spec/colour_spec.rb
+++ b/spec/colour_spec.rb
@@ -14,4 +14,10 @@ describe CR::Colour do
       expect(CR::Colours[:red]).to be CR::Colours::RED
     end
   end
+
+  describe 'to_s' do
+    it 'returns the Colours name' do
+      expect(CR::Colours[:red].to_s).to eq("red")
+    end
+  end
 end

--- a/spec/season_spec.rb
+++ b/spec/season_spec.rb
@@ -14,4 +14,10 @@ describe CR::Season do
       expect(CR::Seasons[:lent]).to be CR::Seasons::LENT
     end
   end
+
+  describe 'to_s' do
+    it 'returns the name of the Season' do
+      expect(CR::Seasons[:lent].to_s).to eq("Lent")
+    end
+  end
 end


### PR DESCRIPTION
Fixes #17

In response to your question, yes the ruby way to go about doing this is to override the `to_s` method on the model. Here we reuse the `name` method that's already been implemented.