### PR TITLE
Move dependencies to calendarium-romanum.gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,23 +1,4 @@
 source 'https://rubygems.org'
 
-gem 'thor'
-gem 'i18n'
-gem 'roman-numerals'
-
-group :development, :test do
-  gem 'rake'
-end
-
-group :development do
-  gem 'rubocop'
-end
-
-group :test do
-  gem 'rspec'
-  gem 'aruba'
-  # We don't use cucumber, but it is required by aruba
-  # and cucumber >= 3.0.0 requires ruby >= 2.1,
-  # but we want the tests to pass on ruby 2.0 as earliest target
-  gem 'cucumber', '~> 2.99'
-  gem 'simplecov'
-end
+# Load dependencies from calendarium-romanum.gemspec
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+PATH
+  remote: .
+  specs:
+    calendarium-romanum (0.5.0)
+      i18n (~> 0.6)
+      roman-numerals (~> 0.3)
+      thor (~> 0.18)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -68,15 +76,13 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  aruba
+  aruba (~> 0.8)
+  calendarium-romanum!
   cucumber (~> 2.99)
-  i18n
-  rake
-  roman-numerals
-  rspec
-  rubocop
-  simplecov
-  thor
+  rake (~> 12.0)
+  rspec (~> 3.5)
+  rubocop (~> 0.46)
+  simplecov (~> 0.12)
 
 BUNDLED WITH
-   1.13.6
+   1.17.2

--- a/calendarium-romanum.gemspec
+++ b/calendarium-romanum.gemspec
@@ -24,4 +24,11 @@ Gem::Specification.new do |s|
   s.add_dependency 'roman-numerals', '~> 0.3'
   s.add_development_dependency 'rake', '~> 12.0'
   s.add_development_dependency 'rspec', '~> 3.5'
+  s.add_development_dependency 'aruba', '~> 0.8'
+  # We don't use cucumber, but it is required by aruba
+  # and cucumber >= 3.0.0 requires ruby >= 2.1,
+  # but we want the tests to pass on ruby 2.0 as earliest target
+  s.add_development_dependency 'cucumber', '~>2.99'
+  s.add_development_dependency 'simplecov', '~> 0.12'
+  s.add_development_dependency 'rubocop', '~> 0.46'
 end


### PR DESCRIPTION
I'm trying to set up a development environment for calendarium-romanum
and manage my gem dependencies with [Bundler](https://bundler.io/). So,
I'd like to be able to do something like `bundle install --path
vendor/bundle` followed by `bundle exec calendariumrom`. Currently, this
doesn't work because even after running `bundle install`, it does not
know about the `calendarium-romanum` gem itself.

In looking for the solution to this, I found [this
page](https://bundler.io/v2.0/guides/creating_gem.html) in the Bundler
docs. It notes that the `Gemfile`:

> contains a gemspec line meaning that Bundler will include dependencies
> specified in foodie.gemspec too. It’s best practice to specify all the
> gems that our library depends on in the gemspec.

Additionally,

> Bundler detects our gem, loads the gemspec and bundles our gem just
> like every other gem.

So, I've added a `gemspec` line to `Gemfile`. Then, I moved dependencies
to `calendarium-romanum.gemspec`.

**Before:**

```
$ bundle install --path vendor/bundle
Bundle complete! 9 Gemfile dependencies, 33 gems now installed.
Bundled gems are installed into `./vendor/bundle`
$ bundle exec calendariumrom
bundler: command not found: calendariumrom
Install missing gem executables with `bundle install`
```

**After:**

```
$ bundle install --path vendor/bundle
Using calendarium-romanum 0.5.0 from source at `.`
Bundle complete! 7 Gemfile dependencies, 34 gems now installed.
Bundled gems are installed into `./vendor/bundle`
$ bundle exec calendariumrom
Commands:
  ...
```

Supporting this workflow should make it easier for other developers to
run the gem after building it themselves, which should make it easier to
test, develop, and contribute.