### PR TITLE
Kill I18n deprecation warning

### DIFF
--- a/bin/calendariumrom
+++ b/bin/calendariumrom
@@ -3,4 +3,7 @@
 require 'calendarium-romanum'
 require 'calendarium-romanum/cli'
 
+# Don't warn about enforcing locales in the CLI.
+I18n.config.enforce_available_locales = true
+
 CalendariumRomanum::CLI.start ARGV


### PR DESCRIPTION
**Before:**

```
$ bundle exec calendariumrom query 2019-09-22
[deprecated] I18n.enforce_available_locales will default to true in the future. If you really want to skip validation of your locale you can set I18n.enforce_available_locales = false to avoid this message.
2019-09-22
season: Ordinary Time

Sunday : 25th Sunday in Ordinary Time
```

**After:**

```
$ bundle exec calendariumrom query 2019-09-22
2019-09-22
season: Ordinary Time

Sunday : 25th Sunday in Ordinary Time
```

I assume it would be preferable to set this value to `true` so an error
is raised if a locale is not available.

<https://stackoverflow.com/questions/20361428/rails-i18n-validation-deprecation-warning>