### PR TITLE
Include primary celebrations in CLI output

### DIFF
--- a/lib/calendarium-romanum/cli.rb
+++ b/lib/calendarium-romanum/cli.rb
@@ -131,10 +131,13 @@ module CalendariumRomanum
 
       rank_length = day.celebrations.collect {|c| c.rank.short_desc.nil? ? 0 : c.rank.short_desc.size }.max
       day.celebrations.each do |c|
-        next if c.rank.short_desc.nil?
-        print c.rank.short_desc.rjust(rank_length)
-        print ' : '
-        puts c.title
+        if [Ranks::PRIMARY, Ranks::TRIDUUM].include? c.rank
+          puts c.title
+        elsif !c.rank.short_desc.nil?
+          print c.rank.short_desc.rjust(rank_length)
+          print ' : '
+          puts c.title
+        end
       end
     end
 

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -142,6 +142,13 @@ describe CalendariumRomanum::CLI, type: :aruba do
         it { expect(all_output).to include 'Saint Paul of the Cross, priest' }
         it { expect(last_command).to be_successfully_executed }
       end
+
+      describe 'prints primary celebrations' do
+        before(:each) { run 'calendariumrom query 2018-12-25' }
+
+        it { expect(all_output).to include "2018-12-25\nseason: Christmas Season\n\nChristmas" }
+        it { expect(last_command).to be_successfully_executed }
+      end
     end
 
     describe 'calendars' do


### PR DESCRIPTION
Primary and triduum celebrations were not being printed in CLI output
because they did not have a short description for their rank.

**Before:**
```
$ bundle exec calendariumrom query 2018-12-25
2018-12-25
season: Christmas Season
```

**After:**
```
$ bundle exec calendariumrom query 2018-12-25
2018-12-25
season: Christmas Season

Christmas
```