### PR TITLE
Improve developer instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,15 +488,21 @@ liturgical calendar for your command line.
  - `calendariumrom` lists available subcommands
  - `calendariumrom help [COMMAND]` outputs a short help for all available subcommands
 
-## How to run tests
+## For Developers
 
-Get the sources, install development dependencies
+Get the sources and install development depencencies:
 
-`bundle install`
+1. `git clone git@github.com:igneus/calendarium-romanum.git`
+2. `cd calendarium-romanum`
+3. `bundle install` or `bundle install --path vendor/bundle`
 
-then execute tests with
+### Run from CLI
 
-`rake spec`
+`bundle exec ruby -Ilib bin/calendariumrom`
+
+### Run Tests
+
+`bundle exec rake spec`
 
 See also `.travis.yml` for comprehensive tests run on the CI.
 


### PR DESCRIPTION
When I started working on a few minor contributions last month, it was
not obvious to me how it should be run. I tried a couple things:

    $ ./bin/calendariumrom
    Traceback (most recent call last):
    	2: from ./bin/calendariumrom:3:in `<main>'
    	1: from /usr/lib/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:59:in `require'
    /usr/lib/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:59:in `require': cannot load such file -- calendarium-romanum (LoadError)

    $ bundle exec bin/calendariumrom
    bundler: failed to load command: bin/calendariumrom (bin/calendariumrom)
    LoadError: cannot load such file -- calendarium-romanum
      bin/calendariumrom:3:in `require'
      bin/calendariumrom:3:in `<top (required)>'

Unfortunately, these all resulted in errors. The solution is to run with
`-Ilib`:

    $ bundle exec ruby -Ilib bin/calendariumrom
    Commands:
      calendariumrom calendars          # lists calendars available for querying

This commit adds some instructions to the README so developers know how
to do this if they want to run calendariumrom from the source code.