### PR TITLE
Implement SanctoraleWriter

### DIFF
--- a/lib/calendarium-romanum.rb
+++ b/lib/calendarium-romanum.rb
@@ -25,6 +25,7 @@ end
   temporale
   sanctorale
   sanctorale_loader
+  sanctorale_writer
   sanctorale_factory
   transfers
   util

--- a/lib/calendarium-romanum/sanctorale_writer.rb
+++ b/lib/calendarium-romanum/sanctorale_writer.rb
@@ -30,7 +30,7 @@ module CalendariumRomanum
       Ranks::FERIAL => 'm3.13',
 
       Ranks::COMMEMORATION => '4.0'
-    }
+    }.freeze
 
     # @api private
     COLOUR_CODES = {
@@ -54,7 +54,7 @@ module CalendariumRomanum
 
       # Write metadata to YAML if present
       unless src.metadata.nil? || src.metadata.empty?
-        dest << src.metadata.transform_keys(&:to_s).to_yaml
+        dest << src.metadata.to_yaml
         dest << "---\n"
       end
 

--- a/lib/calendarium-romanum/sanctorale_writer.rb
+++ b/lib/calendarium-romanum/sanctorale_writer.rb
@@ -1,0 +1,119 @@
+require 'yaml'
+
+module CalendariumRomanum
+
+  # Understands a custom plaintext calendar format
+  # and knows how to transform the {Celebration}s in a
+  # {Sanctorale} to this format.
+  #
+  # For specification of the data format see {file:data/README.md}
+  # of the data directory, For a complete example see e.g.
+  # {file:universal-en.txt the file describing General Roman Calendar}.
+  class SanctoraleWriter
+
+    # @api private
+    RANK_CODES = {
+      Ranks::TRIDUUM => 's1.1',
+      Ranks::PRIMARY => 's1.2',
+      Ranks::SOLEMNITY_GENERAL => 's',
+      Ranks::SOLEMNITY_PROPER => 's1.4',
+
+      Ranks::FEAST_LORD_GENERAL => 'f2.5',
+      Ranks::SUNDAY_UNPRIVILEGED => 'f2.6',
+      Ranks::FEAST_GENERAL => 'f',
+      Ranks::FEAST_PROPER => 'f2.8',
+      Ranks::FERIAL_PRIVILEGED => 'f2.9',
+
+      Ranks::MEMORIAL_GENERAL => 'm',
+      Ranks::MEMORIAL_PROPER => 'm3.11',
+      Ranks::MEMORIAL_OPTIONAL => 'm3.12',
+      Ranks::FERIAL => 'm3.13',
+
+      Ranks::COMMEMORATION => '4.0'
+    }
+
+    # @api private
+    COLOUR_CODES = {
+      Colours::WHITE => 'W',
+      Colours::VIOLET => 'V',
+      Colours::GREEN => 'G',
+      Colours::RED => 'R'
+    }.freeze
+
+
+    # Write to an object which understands +#<<+
+    #
+    # @param src [Sanctorale]
+    #   source of the loaded data
+    # @param dest [String, File, #<<]
+    #   object to populate. If not provided, a new {String}
+    #   instance will be created and returned
+    # @return [String]
+    def write(src, dest = nil)
+      dest ||= String.new
+
+      # Write metadata to YAML if present
+      unless src.metadata.nil? || src.metadata.empty?
+        dest << src.metadata.transform_keys(&:to_s).to_yaml
+        dest << "---\n"
+      end
+
+      # Write each celebration, grouped by month with headings
+      current_month = 0
+      src.each_day.sort_by{ |date, _| date }.each do |date, celebrations|
+        if date.month > current_month 
+          current_month = date.month
+          dest << "\n= #{current_month}\n"
+        end
+
+        celebrations.each do |c|
+          dest << celebration_line(c)
+          dest << "\n"
+        end
+      end
+
+      dest
+    end
+
+
+    alias write_to_string write
+
+
+    # Write to a filesystem path
+    #
+    # @param sanctorale [Sanctorale]
+    # @param filename [String]
+    # @param encoding [String]
+    def write_to_file(sanctorale, filename, encoding = 'utf-8')
+      f = File.open(filename, 'w', encoding: encoding)
+      write(sanctorale, f)
+      f.close()
+    end
+
+    private
+
+    # Convert a {Celebration} to a {String} for writing
+    def celebration_line(celebration)
+      line = "#{celebration.date.day} "
+
+      unless celebration.rank == Ranks::MEMORIAL_OPTIONAL
+        code = RANK_CODES[celebration.rank]
+        line << "#{code} "
+      end
+
+      unless celebration.colour == Colours::WHITE
+        code = COLOUR_CODES[celebration.colour]
+        line << "#{code} "
+      end
+
+      unless celebration.symbol.nil?
+        line << "#{celebration.symbol} "
+      end
+
+      line << ': '
+      line << celebration.title
+
+      line
+    end
+  end
+end

--- a/lib/calendarium-romanum/sanctorale_writer.rb
+++ b/lib/calendarium-romanum/sanctorale_writer.rb
@@ -67,7 +67,7 @@ module CalendariumRomanum
         end
 
         celebrations.each do |c|
-          dest << celebration_line(c)
+          dest << celebration_line(date, c)
           dest << "\n"
         end
       end
@@ -93,8 +93,8 @@ module CalendariumRomanum
     private
 
     # Convert a {Celebration} to a {String} for writing
-    def celebration_line(celebration)
-      line = "#{celebration.date.day} "
+    def celebration_line(date, celebration)
+      line = "#{date.day} "
 
       unless celebration.rank == Ranks::MEMORIAL_OPTIONAL
         code = RANK_CODES[celebration.rank]

--- a/spec/sanctorale_writer_spec.rb
+++ b/spec/sanctorale_writer_spec.rb
@@ -1,0 +1,140 @@
+require 'spec_helper'
+
+describe CR::SanctoraleWriter do
+  let(:s) { CR::Sanctorale.new }
+  let(:d) { CR::SanctoraleWriter.new }
+
+  describe 'record/file format' do
+    let(:celebration) do
+      CR::Celebration.new(
+        'The Most Holy Name of Jesus',
+        CR::Ranks::MEMORIAL_OPTIONAL,
+        CR::Colours::WHITE,
+        :name_jesus,
+        CR::AbstractDate.new(1, 3)
+      )  
+    end
+    let(:result) { d.send(:celebration_line, celebration) }
+
+    describe 'day' do
+      it 'prints the day' do
+        expect(result[0]).to eq('3')
+      end
+    end
+
+    describe 'rank' do
+      describe 'memorial' do
+        let(:celebration) do
+          CR::Celebration.new(
+            'Saints Joachim and Anne',
+            CR::Ranks::MEMORIAL_GENERAL,
+            CR::Colours::WHITE,
+            :joachim_anne,
+            CR::AbstractDate.new(7, 26)
+          )  
+        end
+        it 'includes m as rank' do
+          expect(result).to include(' m ')
+        end
+      end
+      describe 'feast' do
+        let(:celebration) do
+          CR::Celebration.new(
+            'Saints Michael, Gabriel and Raphael, Archangels',
+            CR::Ranks::FEAST_GENERAL,
+            CR::Colours::WHITE,
+            :archangels,
+            CR::AbstractDate.new(9, 29)
+          )  
+        end
+        it 'includes f as rank' do
+          expect(result).to include(' f ')
+        end
+      end
+      describe 'solemnity' do
+        let(:celebration) do
+          CR::Celebration.new(
+            'Immaculate Conception of the Blessed Virgin Mary',
+            CR::Ranks::SOLEMNITY_GENERAL,
+            CR::Colours::WHITE,
+            :bvm_immaculate,
+            CR::AbstractDate.new(12, 8)
+          )  
+        end
+        it 'includes s as rank' do
+          expect(result).to include(' s ')
+        end
+      end
+
+      describe 'feast of the lord' do
+        let(:celebration) do
+          CR::Celebration.new(
+            'Transfiguration of the Lord',
+            CR::Ranks::FEAST_LORD_GENERAL,
+            CR::Colours::WHITE,
+            :transfiguration,
+            CR::AbstractDate.new(8, 6)
+          )  
+        end
+        it 'includes f2.5 as rank' do
+          expect(result).to include(' f2.5 ')
+        end
+      end
+    end
+    
+    describe 'colour' do
+      describe 'red' do
+        let(:celebration) do
+          CR::Celebration.new(
+            'Saint Maximilian Mary Kolbe, priest and martyr',
+            CR::Ranks::MEMORIAL_GENERAL,
+            CR::Colours::RED,
+            :kolbe,
+            CR::AbstractDate.new(8, 14)
+          )  
+        end
+        it 'includes R as colour' do
+          expect(result).to include(' R ')
+        end
+      end
+    end
+  end
+  
+  describe 'YAML front matter (YFM)' do
+    it 'writes YFM if metadata is present' do
+      s.metadata = {foo: 'bar'}
+      expect(d.write_to_string(s))
+        .to eq("---\nfoo: bar\n---\n")
+    end
+
+    it 'does not write YFM if no metadata is present' do
+      expect(d.write_to_string(s)).to eq('')
+    end
+  end
+
+  describe 'complete output' do
+    it 'writes a simple but complete file correctly' do
+      celebration =
+        CR::Celebration.new(
+          'Triumph of the Holy Cross',
+          CR::Ranks::FEAST_LORD_GENERAL,
+          CR::Colours::RED,
+          :cross,
+          CR::AbstractDate.new(9, 14)
+        )
+      s.add(9, 14, celebration)
+      s.metadata = { metadata: 'test' }
+
+      expected = <<~END
+        ---
+        metadata: test
+        ---
+
+        = 9
+        14 f2.5 R cross : Triumph of the Holy Cross
+      END
+
+      expect(d.write_to_string(s)).to eq(expected)
+    end
+  end
+end

--- a/spec/sanctorale_writer_spec.rb
+++ b/spec/sanctorale_writer_spec.rb
@@ -8,11 +8,11 @@ describe CR::SanctoraleWriter do
     let(:celebration) do
       CR::Celebration.new(
         title: 'The Most Holy Name of Jesus',
-        symbol: :name_jesus,
-        date: CR::AbstractDate.new(1, 3)
+        symbol: :name_jesus
       )  
     end
-    let(:result) { d.send(:celebration_line, celebration) }
+    let(:date) { CR::AbstractDate.new(1, 3) }
+    let(:result) { d.send(:celebration_line, date, celebration) }
 
     describe 'day' do
       it 'prints the day' do
@@ -36,8 +36,7 @@ describe CR::SanctoraleWriter do
       describe 'memorial' do
         let(:celebration) do
           CR::Celebration.new(
-            rank: CR::Ranks::MEMORIAL_GENERAL,
-            date: CR::AbstractDate.new(7, 26)
+            rank: CR::Ranks::MEMORIAL_GENERAL
           )  
         end
         it 'includes m as rank' do
@@ -47,8 +46,7 @@ describe CR::SanctoraleWriter do
       describe 'feast' do
         let(:celebration) do
           CR::Celebration.new(
-            rank: CR::Ranks::FEAST_GENERAL,
-            date: CR::AbstractDate.new(9, 29)
+            rank: CR::Ranks::FEAST_GENERAL
           )  
         end
         it 'includes f as rank' do
@@ -58,8 +56,7 @@ describe CR::SanctoraleWriter do
       describe 'solemnity' do
         let(:celebration) do
           CR::Celebration.new(
-            rank: CR::Ranks::SOLEMNITY_GENERAL,
-            date: CR::AbstractDate.new(12, 8)
+            rank: CR::Ranks::SOLEMNITY_GENERAL
           )  
         end
         it 'includes s as rank' do
@@ -70,8 +67,7 @@ describe CR::SanctoraleWriter do
       describe 'feast of the lord' do
         let(:celebration) do
           CR::Celebration.new(
-            rank: CR::Ranks::FEAST_LORD_GENERAL,
-            date: CR::AbstractDate.new(8, 6)
+            rank: CR::Ranks::FEAST_LORD_GENERAL
           )  
         end
         it 'includes f2.5 as rank' do
@@ -84,8 +80,7 @@ describe CR::SanctoraleWriter do
       describe 'red' do
         let(:celebration) do
           CR::Celebration.new(
-            colour: CR::Colours::RED,
-            date: CR::AbstractDate.new(8, 14)
+            colour: CR::Colours::RED
           )  
         end
         it 'includes R as colour' do
@@ -94,17 +89,10 @@ describe CR::SanctoraleWriter do
       end
     end
   end
-
-  describe 'exceptional cases' do
-    it 'raises an exception if no date is provided' do
-      c = CR::Celebration.new
-      expect { d.send(:celebration_line, c) }.to raise_exception(NoMethodError)
-    end
-  end
   
   describe 'YAML front matter (YFM)' do
     it 'writes YFM if metadata is present' do
-      s.metadata = {'foo' => 'bar'}
+      s.metadata = { 'foo' => 'bar' }
       expect(d.write_to_string(s))
         .to eq("---\nfoo: bar\n---\n")
     end


### PR DESCRIPTION
`SanctoraleLoader` is a class that already exists to read a txt file
into a `Sanctorale` instance. It would be nice to also have a
`SanctoraleWriter` class to do this operation in reverse, writing
`Sanctorale` data to a txt file in the same format.

The `SanctoraleWriter` is probably less complicated than the loader
because we don't need to do any regex or other pattern matching. We
simply iterate the celebrations in the `Sanctorale` and write a line for
each.

There was some room for judgement here because the file format allows
for a couple different variations of the way months or ranks could be
serialized. I opted to serialize using the preferences that
`universal-en.txt` was already using, which also seemed to make the file
the most readable. (E.g. We serialize month headings rather than writing
the month on every line). An added benefit is that we can deserialize
and then serialize `universal-en.txt` and compare the results. I've done
this, and the results are identical, except for the comment in the YAML
frontmatter (which isn't stored in the Sanctorale).

This fixes #60.