### PR TITLE
[WIP, RFC] Extensibility improvements

### DIFF
--- a/lib/calendarium-romanum.rb
+++ b/lib/calendarium-romanum.rb
@@ -4,6 +4,8 @@
 module CalendariumRomanum
 end
 
+require 'date'
+
 %w(
   version
   i18n_setup

--- a/lib/calendarium-romanum.rb
+++ b/lib/calendarium-romanum.rb
@@ -21,9 +21,9 @@ require 'date'
   perpetual_calendar
   base_temporale
   temporale/celebration_factory
-  temporale
   temporale/date_helper
   temporale/dates
+  temporale
   temporale/easter_table
   temporale/extensions
   temporale/extensions/christ_eternal_priest

--- a/lib/calendarium-romanum.rb
+++ b/lib/calendarium-romanum.rb
@@ -26,6 +26,7 @@ require 'date'
   temporale/extensions
   temporale/extensions/christ_eternal_priest
   temporale/extensions/dedication_before_all_saints
+  base_temporale
   temporale
   sanctorale
   sanctorale_loader

--- a/lib/calendarium-romanum.rb
+++ b/lib/calendarium-romanum.rb
@@ -19,15 +19,15 @@ require 'date'
   day
   calendar
   perpetual_calendar
+  base_temporale
+  temporale/celebration_factory
+  temporale
   temporale/date_helper
   temporale/dates
-  temporale/celebration_factory
   temporale/easter_table
   temporale/extensions
   temporale/extensions/christ_eternal_priest
   temporale/extensions/dedication_before_all_saints
-  base_temporale
-  temporale
   sanctorale
   sanctorale_loader
   sanctorale_writer

--- a/lib/calendarium-romanum/base_temporale.rb
+++ b/lib/calendarium-romanum/base_temporale.rb
@@ -50,7 +50,11 @@ module CalendariumRomanum
 
         # Define instance method returning the celebration's date for the given year
         define_method symbol do
-          date_callable.call year
+          if date_callable.is_a? Proc
+            instance_eval &date_callable
+          else
+            date_callable.call year
+          end
         end
       end
 
@@ -230,7 +234,12 @@ module CalendariumRomanum
     end
 
     def prepare_celebration_date(date_callable, celebration)
-      date = date_callable.call(year)
+      date =
+        if date_callable.is_a? Proc
+          instance_eval &date_callable
+        else
+          date_callable.call(year)
+        end
 
       add_to =
         if celebration.feast?

--- a/lib/calendarium-romanum/base_temporale.rb
+++ b/lib/calendarium-romanum/base_temporale.rb
@@ -71,13 +71,13 @@ module CalendariumRomanum
       # @api private
       def celebration_dates_provider
         @celebration_dates_provider ||
-          CR::Temporale::Dates
+          Temporale::Dates
       end
 
       # @api private
       def get_celebration_factory
         @celebration_factory ||
-          CR::Temporale::CelebrationFactory
+          Temporale::CelebrationFactory
       end
     end
 
@@ -94,14 +94,14 @@ module CalendariumRomanum
     #
     # @return [Date]
     def start_date
-      CR::Temporale::Dates.first_advent_sunday(year)
+      Temporale::Dates.first_advent_sunday(year)
     end
 
     # Last day of the liturgical year
     #
     # @return [Date]
     def end_date
-      CR::Temporale::Dates.first_advent_sunday(year + 1) - 1
+      Temporale::Dates.first_advent_sunday(year + 1) - 1
     end
 
     # Date range of the liturgical year

--- a/lib/calendarium-romanum/base_temporale.rb
+++ b/lib/calendarium-romanum/base_temporale.rb
@@ -31,7 +31,7 @@ module CalendariumRomanum
       def seasons
         @seasons ||
           (superclass.respond_to?(:seasons) && superclass.seasons) ||
-          CR::Seasons.all
+          [Season.new(nil, nil) { true }]
       end
 
       private

--- a/lib/calendarium-romanum/base_temporale.rb
+++ b/lib/calendarium-romanum/base_temporale.rb
@@ -1,0 +1,232 @@
+module CalendariumRomanum
+  class BaseTemporale
+    class << self
+      # List of celebrations with movable date
+      def celebrations
+        @celebrations ||=
+          if superclass.respond_to? :celebrations
+            superclass.celebrations.dup
+          else
+            []
+          end
+      end
+
+      # Factory method creating temporale {Celebration}s
+      # with sensible defaults
+      #
+      # See {Celebration#initialize} for argument description.
+      def create_celebration(title, rank, colour, symbol: nil, date: nil, sunday: nil)
+        Celebration.new(
+          title: title,
+          rank: rank,
+          colour: colour,
+          symbol: symbol,
+          date: date,
+          cycle: :temporale,
+          sunday: sunday
+        )
+      end
+
+      private
+
+      C = Struct.new(:date_method, :celebration)
+      private_constant :C
+
+      # Call in class body to define a movable celebration
+      def celebration(symbol, date: nil, &blk)
+        date_callable = date || celebration_dates_provider.method(symbol)
+
+        celebrations << C.new(
+          date_callable,
+          blk ? blk.call : get_celebration_factory.public_send(symbol)
+        )
+
+        # Define instance method returning the celebration's date for the given year
+        define_method symbol do
+          date_callable.call year
+        end
+      end
+
+      # Call in class body to set custom celebration dates provider
+      def celebration_dates(provider)
+        @celebration_dates_provider = provider
+      end
+
+      # Call in class body to set custom celebration factory
+      def celebration_factory(factory)
+        @celebration_factory = factory
+      end
+
+      # @api private
+      def celebration_dates_provider
+        @celebration_dates_provider ||
+          CR::Temporale::Dates
+      end
+
+      # @api private
+      def get_celebration_factory
+        @celebration_factory ||
+          CR::Temporale::CelebrationFactory
+      end
+    end
+
+    def initialize(year)
+      @year = year
+
+      prepare_solemnities
+    end
+
+    # @return [Integer]
+    attr_reader :year
+
+    # First day of the liturgical year
+    #
+    # @return [Date]
+    def start_date
+      CR::Temporale::Dates.first_advent_sunday(year)
+    end
+
+    # Last day of the liturgical year
+    #
+    # @return [Date]
+    def end_date
+      CR::Temporale::Dates.first_advent_sunday(year + 1) - 1
+    end
+
+    # Date range of the liturgical year
+    #
+    # @return [Range<Date>]
+    def date_range
+      start_date .. end_date
+    end
+
+    # Retrieve temporale celebration for the given day
+    #
+    # @param date [Date]
+    # @return [Celebration]
+    # @since 0.6.0
+    def [](date)
+      sw = season_and_week(date)
+
+      @solemnities[date] || @feasts[date] || sunday(date, sw) || @memorials[date] || ferial(date, sw)
+    end
+
+    # Enumerates dates and celebrations
+    #
+    # @yield [Date, Celebration]
+    # @return [void, Enumerator] if called without a block, returns +Enumerator+
+    # @since 0.8.0
+    def each_day
+      return to_enum(__method__) unless block_given?
+
+      date_range.each {|date| yield date, self[date] }
+    end
+
+    def season(date)
+      Seasons::LENT
+    end
+
+    def season_week(season, date)
+      1
+    end
+
+    private
+
+    SeasonWeek = Struct.new(:season, :week)
+    private_constant :SeasonWeek
+
+    def season_and_week(date)
+      s = season(date)
+      w = season_week(s, date)
+
+      SeasonWeek.new(s, w)
+    end
+
+    # seasons when Sundays have higher rank
+    SEASONS_SUNDAY_PRIMARY = [Seasons::ADVENT, Seasons::LENT, Seasons::EASTER].freeze
+
+    def sunday(date, season_week)
+      return nil unless date.sunday?
+
+      rank = Ranks::SUNDAY_UNPRIVILEGED
+      if SEASONS_SUNDAY_PRIMARY.include?(season_week.season)
+        rank = Ranks::PRIMARY
+      end
+
+      week = Ordinalizer.ordinal season_week.week
+      title = I18n.t "temporale.#{season_week.season.to_sym}.sunday", week: week
+
+      self.class.create_celebration title, rank, season_week.season.colour, sunday: true
+    end
+
+    def ferial(date, season_week = nil)
+      # Normally +season_week+ is provided, but the method is once called also from Calendar
+      # and we definitely don't want Calendar to care that much about Temporale internals
+      # So as to know how to retrieve the value, so in that case we provide it ourselves.
+      season_week ||= season_and_week(date)
+
+      rank = Ranks::FERIAL
+      title = nil
+      case season_week.season
+      when Seasons::ADVENT
+        if date >= Date.new(@year, 12, 17)
+          rank = Ranks::FERIAL_PRIVILEGED
+          nth = Ordinalizer.ordinal(date.day)
+          title = I18n.t 'temporale.advent.before_christmas', day: nth
+        end
+      when Seasons::CHRISTMAS
+        if date < mother_of_god
+          rank = Ranks::FERIAL_PRIVILEGED
+
+          nth = Ordinalizer.ordinal(date.day - nativity.day + 1) # 1-based counting
+          title = I18n.t 'temporale.christmas.nativity_octave.ferial', day: nth
+        elsif date > epiphany
+          title = I18n.t 'temporale.christmas.after_epiphany.ferial', weekday: I18n.t("weekday.#{date.wday}")
+        end
+      when Seasons::LENT
+        if season_week.week == 0
+          title = I18n.t 'temporale.lent.after_ashes.ferial', weekday: I18n.t("weekday.#{date.wday}")
+        elsif date > palm_sunday
+          rank = Ranks::PRIMARY
+          title = I18n.t 'temporale.lent.holy_week.ferial', weekday: I18n.t("weekday.#{date.wday}")
+        end
+        rank = Ranks::FERIAL_PRIVILEGED unless rank > Ranks::FERIAL_PRIVILEGED
+      when Seasons::EASTER
+        if season_week.week == 1
+          rank = Ranks::PRIMARY
+          title = I18n.t 'temporale.easter.octave.ferial', weekday: I18n.t("weekday.#{date.wday}")
+        end
+      end
+
+      week_ord = Ordinalizer.ordinal season_week.week
+      title ||= I18n.t "temporale.#{season_week.season.to_sym}.ferial", week: week_ord, weekday: I18n.t("weekday.#{date.wday}")
+
+      self.class.create_celebration title, rank, season_week.season.colour
+    end
+
+    # prepare dates of temporale solemnities
+    def prepare_solemnities
+      @solemnities = {}
+      @feasts = {}
+      @memorials = {}
+
+      self.class.celebrations.each do |c|
+        prepare_celebration_date c.date_method, c.celebration
+      end
+    end
+
+    def prepare_celebration_date(date_callable, celebration)
+      date = date_callable.call(year)
+
+      add_to =
+        if celebration.feast?
+          @feasts
+        elsif celebration.memorial?
+          @memorials
+        else
+          @solemnities
+        end
+      add_to[date] = celebration
+    end
+  end
+end

--- a/lib/calendarium-romanum/base_temporale.rb
+++ b/lib/calendarium-romanum/base_temporale.rb
@@ -27,6 +27,13 @@ module CalendariumRomanum
         )
       end
 
+      # @return [Array<Season>]
+      def seasons
+        @seasons ||
+          (superclass.respond_to?(:seasons) && superclass.seasons) ||
+          CR::Seasons.all
+      end
+
       private
 
       C = Struct.new(:date_method, :celebration)
@@ -55,6 +62,10 @@ module CalendariumRomanum
       # Call in class body to set custom celebration factory
       def celebration_factory(factory)
         @celebration_factory = factory
+      end
+
+      def set_seasons(ary)
+        @seasons = ary
       end
 
       # @api private
@@ -123,7 +134,10 @@ module CalendariumRomanum
     end
 
     def season(date)
-      Seasons::LENT
+      r = self.class.seasons.find {|s| s.include? date, self }
+      raise RuntimeError.new("No season found for #{date}") if r.nil?
+
+      r
     end
 
     def season_week(season, date)

--- a/lib/calendarium-romanum/calendar.rb
+++ b/lib/calendarium-romanum/calendar.rb
@@ -1,4 +1,3 @@
-require 'date'
 require 'forwardable'
 
 module CalendariumRomanum

--- a/lib/calendarium-romanum/enums.rb
+++ b/lib/calendarium-romanum/enums.rb
@@ -61,10 +61,11 @@ module CalendariumRomanum
     # @param symbol [Symbol] internal identifier
     # @param colour [Colour]
     #   liturgical colour of the season's Sundays and ferials
-    def initialize(symbol, colour)
+    def initialize(symbol, colour, &blk)
       @symbol = symbol
       @colour = colour
       @i18n_key = "temporale.season.#{@symbol}"
+      @date_include = blk
     end
 
     # Liturgical colour of the season's Sundays and ferials
@@ -73,6 +74,14 @@ module CalendariumRomanum
     #
     # @return [Colour, nil]
     attr_reader :colour
+
+    # @param date [Date]
+    # @param temporale [BaseTemporale]
+    def include?(date, temporale)
+      return false if @date_include.nil?
+
+      @date_include.call date, temporale
+    end
   end
 
   # Standard set of liturgical seasons
@@ -84,7 +93,7 @@ module CalendariumRomanum
     LENT = Season.new(:lent, Colours::VIOLET)
     TRIDUUM = Season.new(:triduum, nil)
     EASTER = Season.new(:easter, Colours::WHITE)
-    ORDINARY = Season.new(:ordinary, Colours::GREEN)
+    ORDINARY = Season.new(:ordinary, Colours::GREEN) { true }
 
     values(index_by: :symbol) do
       [

--- a/lib/calendarium-romanum/enums.rb
+++ b/lib/calendarium-romanum/enums.rb
@@ -88,11 +88,21 @@ module CalendariumRomanum
   module Seasons
     extend Enum
 
-    ADVENT = Season.new(:advent, Colours::VIOLET)
-    CHRISTMAS = Season.new(:christmas, Colours::WHITE)
-    LENT = Season.new(:lent, Colours::VIOLET)
-    TRIDUUM = Season.new(:triduum, nil)
-    EASTER = Season.new(:easter, Colours::WHITE)
+    ADVENT = Season.new(:advent, Colours::VIOLET) do |date, temporale|
+      temporale.first_advent_sunday <= date && temporale.nativity > date
+    end
+    CHRISTMAS = Season.new(:christmas, Colours::WHITE) do |date, temporale|
+      temporale.nativity <= date && temporale.baptism_of_lord >= date
+    end
+    LENT = Season.new(:lent, Colours::VIOLET) do |date, temporale|
+      temporale.ash_wednesday <= date && temporale.good_friday > date
+    end
+    TRIDUUM = Season.new(:triduum, nil) do |date, temporale|
+      temporale.good_friday <= date && temporale.easter_sunday >= date
+    end
+    EASTER = Season.new(:easter, Colours::WHITE) do |date, temporale|
+      temporale.easter_sunday < date && temporale.pentecost >= date
+    end
     ORDINARY = Season.new(:ordinary, Colours::GREEN) { true }
 
     values(index_by: :symbol) do

--- a/lib/calendarium-romanum/temporale.rb
+++ b/lib/calendarium-romanum/temporale.rb
@@ -4,7 +4,6 @@ module CalendariumRomanum
   # Handles seasons and celebrations of the temporale cycle
   # for a given liturgical year.
   class Temporale < BaseTemporale
-    set_seasons Seasons.all
 
     # How many days in a week
     WEEK = 7
@@ -12,6 +11,92 @@ module CalendariumRomanum
     # Which solemnities can be transferred to Sunday
     SUNDAY_TRANSFERABLE_SOLEMNITIES =
       %i(epiphany ascension corpus_christi).freeze
+
+    set_seasons Seasons.all
+    celebration_dates Temporale::Dates
+
+    # @!method nativity
+    #   @return [Date]
+    celebration :nativity
+
+    # @!method holy_family
+    #   @return [Date]
+    celebration :holy_family
+
+    # @!method mother_of_god
+    #   @return [Date]
+    celebration :mother_of_god
+
+    # @!method epiphany
+    #   @return [Date]
+    celebration :epiphany, date: proc { Dates.epiphany(year, sunday: transferred_to_sunday?(:epiphany)) }
+
+    # @!method baptism_of_lord
+    #   @return [Date]
+    celebration :baptism_of_lord, date: proc { Dates.baptism_of_lord(year, epiphany_on_sunday: transferred_to_sunday?(:epiphany)) }
+
+    # @!method ash_wednesday
+    #   @return [Date]
+    celebration :ash_wednesday
+
+    # @!method good_friday
+    #   @return [Date]
+    celebration :good_friday
+
+    # @!method holy_saturday
+    #   @return [Date]
+    celebration :holy_saturday
+
+    # @!method palm_sunday
+    #   @return [Date]
+    celebration :palm_sunday
+
+    # @!method easter_sunday
+    #   @return [Date]
+    celebration :easter_sunday
+
+    # @!method ascension
+    #   @return [Date]
+    celebration :ascension, date: proc { Dates.ascension(year, sunday: transferred_to_sunday?(:ascension)) }
+
+    # @!method pentecost
+    #   @return [Date]
+    celebration :pentecost
+
+    # @!method holy_trinity
+    #   @return [Date]
+    celebration :holy_trinity
+
+    # @!method corpus_christi
+    #   @return [Date]
+    celebration :corpus_christi, date: proc { Dates.corpus_christi(year, sunday: transferred_to_sunday?(:corpus_christi)) }
+
+    # @!method sacred_heart
+    #   @return [Date]
+    celebration :sacred_heart
+
+    # @!method christ_king
+    #   @return [Date]
+    celebration :christ_king
+
+    # Immaculate Heart of Mary and Mary, Mother of the Church
+    # are actually movable *sanctorale* feasts,
+    # but as it would make little sense
+    # to add support for movable sanctorale feasts because of
+    # two, we cheat a bit and handle them in temporale.
+
+    # @!method mother_of_church
+    #   @return [Date]
+    celebration :mother_of_church
+
+    # @!method immaculate_heart
+    #   @return [Date]
+    celebration :immaculate_heart
+
+    # @return [Date]
+    def first_advent_sunday
+      Dates.public_send __method__, year
+    end
 
     # @param year [Integer]
     #   the civil year when the liturgical year _begins_
@@ -22,13 +107,11 @@ module CalendariumRomanum
     #   Sunday - see {SUNDAY_TRANSFERABLE_SOLEMNITIES}
     #   for possible values
     def initialize(year, extensions: [], transfer_to_sunday: [])
-      @year = year
-
       @extensions = extensions
       @transfer_to_sunday = transfer_to_sunday.sort
       validate_sunday_transfer!
 
-      prepare_solemnities
+      super year
     end
 
     # @return [Integer]
@@ -73,47 +156,6 @@ module CalendariumRomanum
           sunday: sunday
         )
       end
-
-      C = Struct.new(:date_method, :celebration)
-      private_constant :C
-
-      # @api private
-      def celebrations
-        @celebrations ||=
-          begin
-            %i(
-              nativity
-              holy_family
-              mother_of_god
-              epiphany
-              baptism_of_lord
-              ash_wednesday
-              good_friday
-              holy_saturday
-              palm_sunday
-              easter_sunday
-              ascension
-              pentecost
-              holy_trinity
-              corpus_christi
-              mother_of_church
-              sacred_heart
-              christ_king
-              immaculate_heart
-            ).collect do |symbol|
-              date_method = symbol
-              C.new(
-                date_method,
-                CelebrationFactory.public_send(symbol)
-              )
-            end
-            # Immaculate Heart of Mary and Mary, Mother of the Church
-            # are actually movable *sanctorale* feasts,
-            # but as it would make little sense
-            # to add support for movable sanctorale feasts because of
-            # two, we cheat a bit and handle them in temporale.
-          end
-      end
     end
 
     # Does this instance transfer the specified solemnity to Sunday?
@@ -157,61 +199,6 @@ module CalendariumRomanum
 
       unless date_range.include? date
         raise RangeError.new "Date out of range #{date}"
-      end
-    end
-
-    # @!method nativity
-    #   @return [Date]
-    # @!method holy_family
-    #   @return [Date]
-    # @!method mother_of_god
-    #   @return [Date]
-    # @!method epiphany
-    #   @return [Date]
-    # @!method baptism_of_lord
-    #   @return [Date]
-    # @!method ash_wednesday
-    #   @return [Date]
-    # @!method good_friday
-    #   @return [Date]
-    # @!method holy_saturday
-    #   @return [Date]
-    # @!method palm_sunday
-    #   @return [Date]
-    # @!method easter_sunday
-    #   @return [Date]
-    # @!method ascension
-    #   @return [Date]
-    # @!method pentecost
-    #   @return [Date]
-    # @!method holy_trinity
-    #   @return [Date]
-    # @!method corpus_christi
-    #   @return [Date]
-    # @!method mother_of_church
-    #   @return [Date]
-    # @!method sacred_heart
-    #   @return [Date]
-    # @!method christ_king
-    #   @return [Date]
-    # @!method immaculate_heart
-    #   @return [Date]
-    # @!method first_advent_sunday
-    #   @return [Date]
-    (celebrations.collect(&:date_method) + [:first_advent_sunday])
-      .each do |feast|
-      if SUNDAY_TRANSFERABLE_SOLEMNITIES.include? feast
-        define_method feast do
-          Dates.public_send feast, year, sunday: transferred_to_sunday?(feast)
-        end
-      elsif feast == :baptism_of_lord
-        define_method feast do
-          Dates.public_send feast, year, epiphany_on_sunday: transferred_to_sunday?(:epiphany)
-        end
-      else
-        define_method feast do
-          Dates.public_send feast, year
-        end
       end
     end
 
@@ -417,43 +404,20 @@ module CalendariumRomanum
 
     # prepare dates of temporale solemnities
     def prepare_solemnities
-      @solemnities = {}
-      @feasts = {}
-      @memorials = {}
-
-      self.class.celebrations.each do |c|
-        prepare_celebration_date c.date_method, c.celebration
-      end
+      super
 
       @extensions.each do |extension|
         extension.each_celebration do |date_method, celebration|
-          date_proc = date_method
-          if date_method.is_a? Symbol
-            date_proc = extension.method(date_method)
-          end
+          date_proc =
+            if date_method.is_a? Symbol
+              date_proc = extension.method(date_method)
+            else
+              proc { date_method.call(year) }
+            end
 
           prepare_celebration_date date_proc, celebration
         end
       end
-    end
-
-    def prepare_celebration_date(date_method, celebration)
-      date =
-        if date_method.respond_to? :call
-          date_method.call(year)
-        else
-          public_send(date_method)
-        end
-
-      add_to =
-        if celebration.feast?
-          @feasts
-        elsif celebration.memorial?
-          @memorials
-        else
-          @solemnities
-        end
-      add_to[date] = celebration
     end
 
     def validate_sunday_transfer!

--- a/lib/calendarium-romanum/temporale.rb
+++ b/lib/calendarium-romanum/temporale.rb
@@ -3,7 +3,8 @@ module CalendariumRomanum
   # One of the two main {Calendar} components.
   # Handles seasons and celebrations of the temporale cycle
   # for a given liturgical year.
-  class Temporale
+  class Temporale < BaseTemporale
+    set_seasons Seasons.all
 
     # How many days in a week
     WEEK = 7
@@ -223,29 +224,7 @@ module CalendariumRomanum
     def season(date)
       range_check date
 
-      if first_advent_sunday <= date &&
-         nativity > date
-        Seasons::ADVENT
-
-      elsif nativity <= date &&
-            baptism_of_lord >= date
-        Seasons::CHRISTMAS
-
-      elsif ash_wednesday <= date &&
-            good_friday > date
-        Seasons::LENT
-
-      elsif good_friday <= date &&
-            easter_sunday >= date
-        Seasons::TRIDUUM
-
-      elsif easter_sunday < date &&
-            pentecost >= date
-        Seasons::EASTER
-
-      else
-        Seasons::ORDINARY
-      end
+      super date
     end
 
     # When the specified liturgical season begins

--- a/lib/calendarium-romanum/temporale.rb
+++ b/lib/calendarium-romanum/temporale.rb
@@ -1,5 +1,3 @@
-require 'date'
-
 module CalendariumRomanum
 
   # One of the two main {Calendar} components.

--- a/lib/calendarium-romanum/temporale/celebration_factory.rb
+++ b/lib/calendarium-romanum/temporale/celebration_factory.rb
@@ -1,5 +1,5 @@
 module CalendariumRomanum
-  class Temporale
+  class Temporale < BaseTemporale
     # Provides factory methods building {Celebration}s
     # for temporale feasts
     class CelebrationFactory

--- a/spec/base_temporale_spec.rb
+++ b/spec/base_temporale_spec.rb
@@ -180,8 +180,35 @@ describe CR::BaseTemporale do
       end
     end
 
+    describe 'custom seasons' do
+      it 'is used' do
+        single_season = CR::Season.new(:single, nil) { true }
+        cls = Class.new(described_class) do
+          set_seasons [single_season]
+        end
+
+        t = cls.new year
+        t.date_range.each do |date|
+          expect(t.season(date)).to be single_season
+        end
+      end
+
+      it 'is passed on through inheritance' do
+        single_season = CR::Season.new(:single, nil) { true }
+        cls = Class.new(described_class) do
+          set_seasons [single_season]
+        end
+        child_cls = Class.new(cls)
+
+        t = child_cls.new year
+        t.date_range.each do |date|
+          expect(t.season(date)).to be single_season
+        end
+      end
+    end
+
     describe 'default settings' do
-      xit 'deals with whole year' do
+      it 'deals with whole year' do
         described_class.new(2000).each_day do |date, celebration|
           expect(date).to be_a Date
           expect(celebration).to be_a CR::Celebration

--- a/spec/base_temporale_spec.rb
+++ b/spec/base_temporale_spec.rb
@@ -1,0 +1,192 @@
+require_relative 'spec_helper'
+
+describe CR::BaseTemporale do
+  let(:year) { 2000 }
+
+  describe 'definition of movable celebrations' do
+    it 'has by default no celebrations, not even Easter' do
+      t = described_class.new year
+      celebration = t[CR::Temporale::Dates.easter_sunday(year)]
+      expect(celebration.symbol).to be nil # does not have the :easter_sunday symbol
+    end
+
+    it 'has celebrations specified in class definition' do
+      cls = Class.new(described_class) do
+        celebration :easter_sunday
+      end
+
+      t = cls.new year
+      celebration = t[CR::Temporale::Dates.easter_sunday(year)]
+      expect(celebration).to eq CR::Temporale::CelebrationFactory.easter_sunday
+    end
+
+    describe 'inheritance' do
+      it 'celebrations are passed on through inheritance' do
+        cls = Class.new(described_class) do
+          celebration :easter_sunday
+        end
+        child_cls = Class.new(cls)
+
+        t = child_cls.new year
+        celebration = t[CR::Temporale::Dates.easter_sunday(year)]
+        expect(celebration).to eq CR::Temporale::CelebrationFactory.easter_sunday
+      end
+
+      it 'celebrations defined in child class do not affect parent class' do
+        cls = Class.new(described_class) do
+          celebration :easter_sunday
+        end
+        child_cls = Class.new(cls) do
+          celebration :holy_trinity
+        end
+
+        t = child_cls.new year
+        expect(t[CR::Temporale::Dates.holy_trinity(year)])
+          .to eq CR::Temporale::CelebrationFactory.holy_trinity
+
+        pt = cls.new year
+        expect(pt[CR::Temporale::Dates.holy_trinity(year)])
+          .not_to eq CR::Temporale::CelebrationFactory.holy_trinity
+      end
+    end
+
+    describe '.celebration method signature' do
+      it 'optional block used to build the celebration' do
+        expected_value = CR::Celebration.new
+
+        cls = Class.new(described_class) do
+          celebration :easter_sunday do
+            expected_value
+          end
+        end
+
+        t = cls.new year
+        celebration = t[CR::Temporale::Dates.easter_sunday(year)]
+        expect(celebration).to be expected_value
+      end
+
+      it 'optional argument computing date' do
+        date_proc = double(Proc)
+        expect(date_proc).to receive(:call).and_return(Date.new(2000, 12, 1))
+
+        cls = Class.new(described_class) do
+          celebration :easter_sunday, date: date_proc
+        end
+
+        t = cls.new year
+        celebration = t[Date.new(2000, 12, 1)]
+        expect(celebration).to eq CR::Temporale::CelebrationFactory.easter_sunday
+      end
+    end
+
+    describe 'custom dates provider' do
+      it 'is used' do
+        dates = double(easter_sunday: Date.new(2000, 12, 1))
+
+        cls = Class.new(described_class) do
+          celebration_dates dates
+          celebration :easter_sunday
+        end
+
+        t = cls.new year
+        celebration = t[Date.new(2000, 12, 1)]
+        expect(celebration).to eq CR::Temporale::CelebrationFactory.easter_sunday
+      end
+
+      it 'is passed on through inheritance' do
+        dates = double(easter_sunday: Date.new(2000, 12, 1))
+
+        cls = Class.new(described_class) do
+          celebration_dates dates
+          celebration :easter_sunday
+        end
+        child_cls = Class.new(cls)
+
+        t = child_cls.new year
+        celebration = t[Date.new(2000, 12, 1)]
+        expect(celebration).to eq CR::Temporale::CelebrationFactory.easter_sunday
+      end
+
+      it 'is used until another one is set' do
+        dates = double(easter_sunday: Date.new(2000, 12, 1))
+        dates_2 = double(holy_trinity: Date.new(2000, 12, 2))
+
+        cls = Class.new(described_class) do
+          celebration_dates dates
+          celebration :easter_sunday
+
+          celebration_dates dates_2
+          celebration :holy_trinity
+        end
+
+        t = cls.new year
+        celebration = t[Date.new(2000, 12, 1)]
+        expect(celebration).to eq CR::Temporale::CelebrationFactory.easter_sunday
+        celebration = t[Date.new(2000, 12, 2)]
+        expect(celebration).to eq CR::Temporale::CelebrationFactory.holy_trinity
+      end
+    end
+
+    describe 'custom celebration factory' do
+      it 'is used' do
+        expected = CR::Celebration.new(symbol: :whatever)
+        factory = double(easter_sunday: expected)
+
+        cls = Class.new(described_class) do
+          celebration_factory factory
+          celebration :easter_sunday
+        end
+
+        t = cls.new year
+        celebration = t[CR::Temporale::Dates.easter_sunday(year)]
+        expect(celebration).to be expected
+      end
+
+      it 'is passed on through inheritance' do
+        expected = CR::Celebration.new(symbol: :whatever)
+        factory = double(easter_sunday: expected)
+
+        cls = Class.new(described_class) do
+          celebration_factory factory
+          celebration :easter_sunday
+        end
+        child_cls = Class.new(cls)
+
+        t = child_cls.new year
+        celebration = t[CR::Temporale::Dates.easter_sunday(year)]
+        expect(celebration).to be expected
+      end
+
+      it 'is used until another one is set' do
+        expected_easter = CR::Celebration.new(symbol: :e)
+        factory = double(easter_sunday: expected_easter)
+
+        expected_trinity = CR::Celebration.new(symbol: :t)
+        factory_2 = double(holy_trinity: expected_trinity)
+
+        cls = Class.new(described_class) do
+          celebration_factory factory
+          celebration :easter_sunday
+
+          celebration_factory factory_2
+          celebration :holy_trinity
+        end
+
+        t = cls.new year
+        celebration = t[CR::Temporale::Dates.easter_sunday(year)]
+        expect(celebration).to be expected_easter
+        celebration = t[CR::Temporale::Dates.holy_trinity(year)]
+        expect(celebration).to be expected_trinity
+      end
+    end
+
+    describe 'default settings' do
+      xit 'deals with whole year' do
+        described_class.new(2000).each_day do |date, celebration|
+          expect(date).to be_a Date
+          expect(celebration).to be_a CR::Celebration
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR addresses some of the most painful issues encountered when working on custom `Temporale` implementations ([1](https://github.com/calendarium-romanum/czech_old_catholic_calendar), [2](https://github.com/RussellHaley/CalendariumAnglicum)), partly covered already in issue #49.

Most importantly new class `BaseTemporale` is extracted as superclass of `Temporale`. It provides facilities for defining `Temporale` implementations customized in most aspects:

* liturgical seasons
* set of temporale feasts/solemnities, their dates and other details

An important change (which I'm not yet 100% decided to leave in place) is moving the logic of season determination (see the new implementation of `Temporale#season`) from `Temporale` to the `Season` instances.

Issues still waiting to be addressed: to make customizable also

* counting of season weeks
* naming and ranks of ferials and Sundays

Comments are most welcome.