### PR TITLE
Support ad hoc celebration date overrides [WIP]

### DIFF
--- a/lib/calendarium-romanum.rb
+++ b/lib/calendarium-romanum.rb
@@ -32,6 +32,7 @@ require 'date'
   sanctorale_writer
   sanctorale_factory
   transfers
+  date_overrider
   util
   ordinalizer
 ).each do |f|

--- a/lib/calendarium-romanum/date_overrider.rb
+++ b/lib/calendarium-romanum/date_overrider.rb
@@ -1,0 +1,70 @@
+module CalendariumRomanum
+  # Church authorities occasionally make ad hoc changes to the liturgical calendar
+  # by moving a {Celebration} just for a given year to a more convenient date.
+  # This class is responsible for storing and applying such changes.
+  class DateOverrider
+    # @param overrides [Hash<Date=>Symbol>]
+    def initialize(overrides = {})
+      @overrides = overrides
+    end
+
+    # Accepts {Temporale} and {Sanctorale}, returns them (if no changes apply)
+    # or their copies with date changes applied.
+    #
+    # @param temporale [Temporale]
+    # @param sanctorale [Sanctorale]
+    # @return [Array<Temporale, Sanctorale>]
+    def call(temporale, sanctorale)
+      range = temporale.date_range
+
+      for_year = @overrides.select {|date, _| range.include? date }
+
+      return [temporale, sanctorale] if for_year.empty?
+
+      for_temporale = {}
+      for_sanctorale = {}
+      for_year.each_pair do |date, symbol|
+        to = temporale.provides_celebration?(symbol) ? for_temporale : for_sanctorale
+        to[date] = symbol
+      end
+
+      new_sanctorale =
+        for_sanctorale.empty? ?
+          sanctorale :
+          sanctorale.merge(sanctorale_layer(for_sanctorale, sanctorale))
+
+      new_temporale =
+        for_temporale.empty? ?
+          temporale :
+          temporale_class(for_temporale, temporale)
+            .new(
+              temporale.year,
+              extensions: temporale.extensions,
+              transfer_to_sunday: temporale.transfer_to_sunday
+            )
+
+      [new_temporale, new_sanctorale]
+    end
+
+    private
+
+    # Returns a new {Sanctorale} applying +overrides+ to +sanctorale+.
+    def sanctorale_layer(overrides, sanctorale)
+      r = Sanctorale.new
+      overrides.each do |date, symbol|
+        orig_date, celebration = sanctorale.by_symbol(symbol)
+        r.replace orig_date.month, orig_date.day, []
+        r.add date.month, date.day, celebration
+      end
+      r
+    end
+
+    def temporale_class(overrides, temporale)
+      Class.new(temporale.class) do
+        overrides.each_pair do |date, symbol|
+          define_method(symbol) { date }
+        end
+      end
+    end
+  end
+end

--- a/lib/calendarium-romanum/temporale.rb
+++ b/lib/calendarium-romanum/temporale.rb
@@ -33,6 +33,12 @@ module CalendariumRomanum
     # @return [Integer]
     attr_reader :year
 
+    # @return [Array<Symbol>]
+    attr_reader :transfer_to_sunday
+
+    # @return [Array<#each_celebration>]
+    attr_reader :extensions
+
     class << self
       # Determines liturgical year for the given date
       #
@@ -360,10 +366,6 @@ module CalendariumRomanum
     def provides_celebration?(symbol)
       @all_celebration_symbols.include? symbol
     end
-
-    protected
-
-    attr_reader :transfer_to_sunday, :extensions
 
     private
 

--- a/liturgical_law/2020_dubia_de_calendario_2022.md
+++ b/liturgical_law/2020_dubia_de_calendario_2022.md
@@ -57,12 +57,13 @@ c) Sollemnitas Nativitatis S. Ioanni Baptistae et sollemnitas Sacratissimi Cordi
 	 II Vesperae omittantur. I Vesperae sollemnitatis Sacratissimi Cordis Iesu celebrentur.
 
 ```ruby
-calendar = CR::Calendar.new 2021, CR::Data::GENERAL_ROMAN_LATIN.load, vespers: true
-
 i23 = Date.new(2022, 6, 23)
 i24 = i23 + 1
 
 expect(i24).to be_friday
+
+overrider = CR::DateOverrider.new({i23 => :baptist_birth})
+calendar = CR::Calendar.new 2021, CR::Data::GENERAL_ROMAN_LATIN.load, vespers: true, overrides: overrider
 
 expect(calendar[i24].celebrations[0].symbol).to be :sacred_heart
 
@@ -77,9 +78,21 @@ feria VI, celebretur; sollemnitas autem Sacratissimi Cordis Iesu ad diem 23 iuni
 feriam V transferatur, usque ad horam Nonam inclusive.
 
 ```ruby
-skip 'there is currently no pretty way how to model this scenario using calendarium-romanum -
-  a custom Temporale is required, either with a changed date of Sacred Heart or with
-  customized solemnity transfer logic'
+i23 = Date.new(2022, 6, 23)
+i24 = i23 + 1
+
+overrider = CR::DateOverrider.new({i23 => :sacred_heart})
+calendar = CR::Calendar.new 2021, CR::Data::GENERAL_ROMAN_LATIN.load, vespers: true, overrides: overrider
+
+day = calendar[i23]
+expect(day.celebrations[0].symbol).to be :sacred_heart
+
+# TODO: Currently we cannot do this as expected, as for calendarium-romanum
+#   the two solemnities have exactly the same rank
+#
+# expect(day.vespers.symbol).to be :baptist_birth
+
+expect(calendar[i24].celebrations[0].symbol).to be :baptist_birth
 ```
 
 d) Dominica XX Temporis "per annum", die 14 augusti.

--- a/spec/date_overrider_spec.rb
+++ b/spec/date_overrider_spec.rb
@@ -1,0 +1,82 @@
+require_relative 'spec_helper'
+
+describe CR::DateOverrider do
+  let(:subject) { described_class.new overrides }
+
+  let(:year) { 2000 }
+  let(:temporale) { CR::Temporale.new year }
+  let(:sanctorale) { CR::Sanctorale.new }
+
+  let(:nullus) { CR::Celebration.new('S. Nullius', CR::Ranks::MEMORIAL_OPTIONAL, CR::Colours::WHITE, :nullus) }
+  let(:ignotus) { CR::Celebration.new('S. Ignoti', CR::Ranks::MEMORIAL_OPTIONAL, CR::Colours::WHITE, :ignotus) }
+
+  describe 'no overrides' do
+    let(:overrides) { {} }
+
+    it 'returns arguments unchanged' do
+      result = subject.call temporale, sanctorale
+
+      expect(result[0]).to be temporale
+      expect(result[1]).to be sanctorale
+    end
+  end
+
+  describe 'overrides for unknown celebrations' do
+    # the overridden celebration is not known to either temporale or sanctorale
+    let(:overrides) { {Date.new(year - 10, 7, 5) => :nullus} }
+
+    it 'returns arguments unchanged' do
+      result = subject.call temporale, sanctorale
+
+      expect(result[0]).to be temporale
+      expect(result[1]).to be sanctorale
+    end
+  end
+
+  describe 'no overrides for the given year' do
+    let(:overrides) { {Date.new(1990, 7, 5) => :nullus} }
+
+    it 'returns arguments unchanged' do
+      sanctorale.add 1, 14, nullus
+
+      result = subject.call temporale, sanctorale
+
+      expect(result[0]).to be temporale
+      expect(result[1]).to be sanctorale
+    end
+  end
+
+  describe 'sanctorale celebration overridden' do
+    let(:overrides) { {Date.new(year + 1, 7, 5) => :nullus} }
+
+    it 'returns sanctorale with the override applied' do
+      pending 'waits for reasonable date moving support in Sanctorale'
+
+      sanctorale.add 1, 14, nullus
+
+      new_temporale, new_sanctorale = subject.call temporale, sanctorale
+
+      expect(new_sanctorale).to be_a CR::Sanctorale
+      expect(new_sanctorale).not_to be sanctorale
+      expect(new_sanctorale.get(7, 5)).to eq [nullus]
+      expect(new_sanctorale.get(1, 17)).to eq []
+
+      expect(new_temporale).to be temporale
+    end
+  end
+
+  describe 'temporale celebration overridden' do
+    let(:overrides) { {Date.new(year + 1, 7, 5) => :corpus_christi} }
+
+    it 'returns temporale with the override applied' do
+      new_temporale, new_sanctorale = subject.call temporale, sanctorale
+
+      expect(new_temporale).to be_a CR::Temporale
+      expect(new_temporale).not_to be temporale
+      expect(new_temporale[Date.new(2001, 7, 5)]).to eq CR::Temporale::CelebrationFactory.corpus_christi
+      expect(new_temporale[CR::Temporale::Dates.corpus_christi(year)]).to be_ferial
+
+      expect(new_sanctorale).to be sanctorale
+    end
+  end
+end


### PR DESCRIPTION
fix #80

Church authorities occasionally make an ad hoc change to the calendar, moving a celebration, just for the given year, to a more convenient date beyond the usual calendar rules. This PR proposes one possible way of addressing this.

Shortcomings:
- as it operates solely on the level of celebration dates, but doesn't otherwise affect the logic of celebration precedence, we still aren't able to compute calendar exactly as ruled in the recent CDW response concerning 2022, since _Corpus Christi_ and _Birth of St. John Baptist_ have exactly the same rank and thus the solemnity receiving first Vespers according to the response doesn't receive them according to `calendarium-romanum`
- it is able to move singular celebrations only (but AFAIK ad hoc moving around has so far never affected e.g. a group of optional memorials on the same date, but always a higher-ranking important celebration; should it nevertheless be needed in future, the logic can be extended)

Comments and and alternative proposals welcome.